### PR TITLE
feature: creates day detail page

### DIFF
--- a/src/app/app-routing.module.ts
+++ b/src/app/app-routing.module.ts
@@ -1,0 +1,17 @@
+import { NgModule } from '@angular/core';
+import { RouterModule, Routes } from '@angular/router';
+
+import { DaysComponent } from './days/days.component';
+import { DayDetailComponent } from './day-detail/day-detail.component';
+
+const routes: Routes = [
+  { path: '', redirectTo: '/days', pathMatch: 'full' },
+  { path: 'days', component: DaysComponent },
+  { path: 'day/:date', component: DayDetailComponent },
+];
+
+@NgModule({
+  imports: [RouterModule.forRoot(routes)],
+  exports: [RouterModule],
+})
+export class AppRoutingModule {}

--- a/src/app/app.component.html
+++ b/src/app/app.component.html
@@ -1,1 +1,1 @@
-<app-days></app-days>
+<router-outlet></router-outlet>

--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -4,9 +4,10 @@ import { FormsModule } from '@angular/forms';
 
 import { AppComponent } from './app.component';
 import { DaysComponent } from './days/days.component';
+import { DayDetailComponent } from './day-detail/day-detail.component';
 
 @NgModule({
-  declarations: [AppComponent, DaysComponent],
+  declarations: [AppComponent, DaysComponent, DayDetailComponent],
   imports: [BrowserModule, FormsModule],
   providers: [],
   bootstrap: [AppComponent],

--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -5,10 +5,11 @@ import { FormsModule } from '@angular/forms';
 import { AppComponent } from './app.component';
 import { DaysComponent } from './days/days.component';
 import { DayDetailComponent } from './day-detail/day-detail.component';
+import { AppRoutingModule } from './app-routing.module';
 
 @NgModule({
   declarations: [AppComponent, DaysComponent, DayDetailComponent],
-  imports: [BrowserModule, FormsModule],
+  imports: [BrowserModule, FormsModule, AppRoutingModule],
   providers: [],
   bootstrap: [AppComponent],
 })

--- a/src/app/day-detail/day-detail.component.html
+++ b/src/app/day-detail/day-detail.component.html
@@ -24,3 +24,4 @@
     />
   </div>
 </div>
+<button (click)="goBack()">back home</button>

--- a/src/app/day-detail/day-detail.component.html
+++ b/src/app/day-detail/day-detail.component.html
@@ -1,0 +1,26 @@
+<div *ngIf="day" class="day-detail">
+  <h2>{{ day.name }} | {{ day.date }}</h2>
+  <input
+    id="thoughts"
+    [(ngModel)]="day.thoughts"
+    placeholder="Today's thoughts..."
+  />
+  <div class="meditated-check">
+    <label>meditated?:</label>
+    <input
+      id="meditated"
+      type="checkbox"
+      value="{{ day.hasMeditated }}"
+      [(ngModel)]="day.hasMeditated"
+    />
+  </div>
+  <div class="workout-check">
+    <label>worked out?:</label>
+    <input
+      id="workout"
+      type="checkbox"
+      value="{{ day.hasWorkedOut }}"
+      [(ngModel)]="day.hasWorkedOut"
+    />
+  </div>
+</div>

--- a/src/app/day-detail/day-detail.component.spec.ts
+++ b/src/app/day-detail/day-detail.component.spec.ts
@@ -1,0 +1,25 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { DayDetailComponent } from './day-detail.component';
+
+describe('DayDetailComponent', () => {
+  let component: DayDetailComponent;
+  let fixture: ComponentFixture<DayDetailComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      declarations: [ DayDetailComponent ]
+    })
+    .compileComponents();
+  });
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(DayDetailComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/src/app/day-detail/day-detail.component.ts
+++ b/src/app/day-detail/day-detail.component.ts
@@ -1,6 +1,9 @@
 import { Component, OnInit, Input } from '@angular/core';
+import { ActivatedRoute } from '@angular/router';
+import { Location } from '@angular/common';
 
 import { Day } from '../day';
+import { DayService } from '../day.service';
 
 @Component({
   selector: 'app-day-detail',
@@ -10,7 +13,22 @@ import { Day } from '../day';
 export class DayDetailComponent implements OnInit {
   @Input() day?: Day;
 
-  constructor() {}
+  constructor(
+    private route: ActivatedRoute,
+    private dayService: DayService,
+    private location: Location
+  ) {}
 
-  ngOnInit(): void {}
+  ngOnInit(): void {
+    this.getDay();
+  }
+
+  getDay(): void {
+    const date = this.route.snapshot.paramMap.get('date') || '';
+    this.dayService.getDay(date).subscribe((day) => (this.day = day));
+  }
+
+  goBack(): void {
+    this.location.back();
+  }
 }

--- a/src/app/day-detail/day-detail.component.ts
+++ b/src/app/day-detail/day-detail.component.ts
@@ -1,0 +1,16 @@
+import { Component, OnInit, Input } from '@angular/core';
+
+import { Day } from '../day';
+
+@Component({
+  selector: 'app-day-detail',
+  templateUrl: './day-detail.component.html',
+  styleUrls: ['./day-detail.component.css'],
+})
+export class DayDetailComponent implements OnInit {
+  @Input() day?: Day;
+
+  constructor() {}
+
+  ngOnInit(): void {}
+}

--- a/src/app/day.service.spec.ts
+++ b/src/app/day.service.spec.ts
@@ -1,0 +1,16 @@
+import { TestBed } from '@angular/core/testing';
+
+import { DayService } from './day.service';
+
+describe('DayService', () => {
+  let service: DayService;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({});
+    service = TestBed.inject(DayService);
+  });
+
+  it('should be created', () => {
+    expect(service).toBeTruthy();
+  });
+});

--- a/src/app/day.service.ts
+++ b/src/app/day.service.ts
@@ -1,0 +1,17 @@
+import { Injectable } from '@angular/core';
+import { Observable, of } from 'rxjs';
+
+import { Day } from './day';
+import { DAYS } from './mock-days';
+
+@Injectable({
+  providedIn: 'root',
+})
+export class DayService {
+  constructor() {}
+
+  getDays(): Observable<Day[]> {
+    const days = of(DAYS);
+    return days;
+  }
+}

--- a/src/app/day.service.ts
+++ b/src/app/day.service.ts
@@ -14,4 +14,9 @@ export class DayService {
     const days = of(DAYS);
     return days;
   }
+
+  getDay(date: string): Observable<Day> {
+    const day = DAYS.find((d) => d.date === date)!;
+    return of(day);
+  }
 }

--- a/src/app/days/days.component.html
+++ b/src/app/days/days.component.html
@@ -1,17 +1,13 @@
 <div class="days-list">
   <ul class="days">
-    <li *ngFor="let day of days">
+    <li *ngFor="let day of days" (click)="onSelect(day)">
       <h1>{{ day.name }}</h1>
       <h2>{{ day.date | uppercase }}</h2>
       <div class="day-images">
         <img *ngFor="let image of day.images" [src]="image" />
       </div>
       <div class="day-thoughts">
-        <input
-          id="thoughts"
-          [(ngModel)]="day.thoughts"
-          placeholder="Today's thoughts..."
-        />
+        <p>{{ day.thoughts }}</p>
       </div>
       <div class="day-booleans">
         <h3>meditated: {{ day.hasMeditated }}</h3>
@@ -19,4 +15,30 @@
       </div>
     </li>
   </ul>
+</div>
+<div *ngIf="selectedDay" class="selected-day">
+  <h2>{{ selectedDay.name }} | {{ selectedDay.date }}</h2>
+  <input
+    id="thoughts"
+    [(ngModel)]="selectedDay.thoughts"
+    placeholder="Today's thoughts..."
+  />
+  <div class="meditated-check">
+    <label>meditated?:</label>
+    <input
+      id="meditated"
+      type="checkbox"
+      value="{{ selectedDay.hasMeditated }}"
+      [(ngModel)]="selectedDay.hasMeditated"
+    />
+  </div>
+  <div class="workout-check">
+    <label>worked out?:</label>
+    <input
+      id="workout"
+      type="checkbox"
+      value="{{ selectedDay.hasWorkedOut }}"
+      [(ngModel)]="selectedDay.hasWorkedOut"
+    />
+  </div>
 </div>

--- a/src/app/days/days.component.html
+++ b/src/app/days/days.component.html
@@ -1,7 +1,9 @@
 <div class="days-list">
   <ul class="days">
-    <li *ngFor="let day of days" (click)="onSelect(day)">
-      <h1>{{ day.name }}</h1>
+    <li *ngFor="let day of days">
+      <a routerLink="/day/{{ day.date }}">
+        <h1>{{ day.name }}</h1></a
+      >
       <h2>{{ day.date | uppercase }}</h2>
       <div class="day-images">
         <img *ngFor="let image of day.images" [src]="image" />
@@ -16,4 +18,3 @@
     </li>
   </ul>
 </div>
-<app-day-detail [day]="selectedDay"></app-day-detail>

--- a/src/app/days/days.component.html
+++ b/src/app/days/days.component.html
@@ -16,29 +16,4 @@
     </li>
   </ul>
 </div>
-<div *ngIf="selectedDay" class="selected-day">
-  <h2>{{ selectedDay.name }} | {{ selectedDay.date }}</h2>
-  <input
-    id="thoughts"
-    [(ngModel)]="selectedDay.thoughts"
-    placeholder="Today's thoughts..."
-  />
-  <div class="meditated-check">
-    <label>meditated?:</label>
-    <input
-      id="meditated"
-      type="checkbox"
-      value="{{ selectedDay.hasMeditated }}"
-      [(ngModel)]="selectedDay.hasMeditated"
-    />
-  </div>
-  <div class="workout-check">
-    <label>worked out?:</label>
-    <input
-      id="workout"
-      type="checkbox"
-      value="{{ selectedDay.hasWorkedOut }}"
-      [(ngModel)]="selectedDay.hasWorkedOut"
-    />
-  </div>
-</div>
+<app-day-detail [day]="selectedDay"></app-day-detail>

--- a/src/app/days/days.component.ts
+++ b/src/app/days/days.component.ts
@@ -1,7 +1,7 @@
 import { Component, OnInit } from '@angular/core';
 
 import { Day } from '../day';
-import { DAYS } from '../mock-days';
+import { DayService } from '../day.service';
 
 @Component({
   selector: 'app-days',
@@ -9,9 +9,15 @@ import { DAYS } from '../mock-days';
   styleUrls: ['./days.component.css'],
 })
 export class DaysComponent implements OnInit {
-  days = DAYS;
+  days: Day[] = [];
 
-  constructor() {}
+  constructor(private dayService: DayService) {}
 
-  ngOnInit(): void {}
+  ngOnInit(): void {
+    this.getDays();
+  }
+
+  getDays(): void {
+    this.dayService.getDays().subscribe((days) => (this.days = days));
+  }
 }

--- a/src/app/days/days.component.ts
+++ b/src/app/days/days.component.ts
@@ -10,13 +10,8 @@ import { DAYS } from '../mock-days';
 })
 export class DaysComponent implements OnInit {
   days = DAYS;
-  selectedDay?: Day;
 
   constructor() {}
 
   ngOnInit(): void {}
-
-  onSelect(day: Day): void {
-    this.selectedDay = day;
-  }
 }

--- a/src/app/days/days.component.ts
+++ b/src/app/days/days.component.ts
@@ -10,8 +10,13 @@ import { DAYS } from '../mock-days';
 })
 export class DaysComponent implements OnInit {
   days = DAYS;
+  selectedDay?: Day;
 
   constructor() {}
 
   ngOnInit(): void {}
+
+  onSelect(day: Day): void {
+    this.selectedDay = day;
+  }
 }

--- a/src/app/mock-days.ts
+++ b/src/app/mock-days.ts
@@ -4,7 +4,7 @@ export const DAYS: Day[] = [
   {
     id: 1,
     name: 'Monday',
-    date: '5 July 2021',
+    date: '5-July-2021',
     images: [
       'https://bit.ly/3ApfOCQ',
       'https://bit.ly/3xj5cDs',
@@ -18,7 +18,7 @@ export const DAYS: Day[] = [
   {
     id: 2,
     name: 'Tuesday',
-    date: '6 July 2021',
+    date: '6-July-2021',
     images: [
       'https://bit.ly/3xj5cDs',
       'https://bit.ly/3qLAmkx',
@@ -32,7 +32,7 @@ export const DAYS: Day[] = [
   {
     id: 3,
     name: 'Wednesday',
-    date: '7 July 2021',
+    date: '7-July-2021',
     images: [
       'https://bit.ly/3qLAmkx',
       'https://bit.ly/3ApfOCQ',


### PR DESCRIPTION
- adds service for getting day and days
- makes parameterized routes for detail page based on dates

closes #2 

## PRR (PR Retro)
I'm not sure there is a need for a separate details page. Ideally, changes can just be made on the same page so users do not have to navigate away and everything they need is right there on page load.

As is, state doesn't persist anyway, so it's just a fun trial.

The use of `of` for observables is kind of confusing, or just not very straightforward. 

Having all the days on the main page while also being editable may be bit much. Will paginate in the future.

## TODO:
consider sans-detail-page design/ui
